### PR TITLE
Add several unicode character codes that t1enc.dfu lacks

### DIFF
--- a/sp.cls
+++ b/sp.cls
@@ -107,6 +107,40 @@
 %========================= required packages =========================
 
 \RequirePackage[utf8]{inputenc}
+% Misc
+\DeclareUnicodeCharacter{301}{\'}
+\DeclareUnicodeCharacter{27E8}{\langle}
+\DeclareUnicodeCharacter{27E9}{\rangle}
+\DeclareUnicodeCharacter{1CE}{\v a}
+% The following shims are based on https://tex.stackexchange.com/a/203804
+% Welsh
+\DeclareUnicodeCharacter{174}{\^W}
+\DeclareUnicodeCharacter{175}{\^w}
+\DeclareUnicodeCharacter{176}{\^Y}
+\DeclareUnicodeCharacter{177}{\^y}
+% Latin vowels with breve
+\DeclareUnicodeCharacter{114}{\u E}
+\DeclareUnicodeCharacter{115}{\u e}
+\DeclareUnicodeCharacter{12C}{\u I}
+\DeclareUnicodeCharacter{12D}{\u\i}
+\DeclareUnicodeCharacter{14E}{\u O}
+\DeclareUnicodeCharacter{14F}{\u o}
+\DeclareUnicodeCharacter{16C}{\u U}
+\DeclareUnicodeCharacter{16D}{\u u}
+% Latin vowels with macron
+\DeclareUnicodeCharacter{100}{\=A}
+\DeclareUnicodeCharacter{101}{\=a}
+\DeclareUnicodeCharacter{112}{\=E}
+\DeclareUnicodeCharacter{113}{\=e}
+\DeclareUnicodeCharacter{12A}{\=I}
+\DeclareUnicodeCharacter{12B}{\=\i}
+\DeclareUnicodeCharacter{14C}{\=O}
+\DeclareUnicodeCharacter{14D}{\=o}
+\DeclareUnicodeCharacter{16A}{\=U}
+\DeclareUnicodeCharacter{16B}{\=u}
+\DeclareUnicodeCharacter{232}{\=Y}
+\DeclareUnicodeCharacter{233}{\=y}
+
 \RequirePackage{xspace}
 % microtype handles punctuation at the right margin. We want it for
 % the final product, but it's okay if authors lack it.


### PR DESCRIPTION
I've lately run into several cases of `pdflatex` complaining about (and not rendering) undefined unicode characters due to biber writing UTF-8 output by default.

AFAICT, this is because `t1enc.dfu` only defines UTF-8 character code translations for a small subset of the characters that LaTeX can produce. I'm not sure why it's not more comprehensive.

This may not be the proper fix. Perhaps biber can be configured, via the biblatex-sp-unified `.bbx` / `.cbx` styles to output TeX-friendly ASCII? But I like UTF-8, and I imagine the biber developers had some reason for the choosing UTF-8 as the default, and this seems like the clearest fix assuming the `.bbl` file is UTF-8-encoded.

Thoughts, @fintelkai ?
