### PR TITLE
Add special handling for literal non-breaking hyphen

### DIFF
--- a/sp.cls
+++ b/sp.cls
@@ -107,6 +107,10 @@
 %========================= required packages =========================
 
 \RequirePackage[utf8]{inputenc}
+% define U+2011 NON-BREAKING HYPHEN as a regular hyphen + line break prohibition
+% Based on http://tex.stackexchange.com/a/23146
+% plain \mbox{-} doesn't allow the suffix to hyphenate automatically
+\DeclareUnicodeCharacter{2011}{\mbox{-}\nobreak\hskip0pt}
 \RequirePackage{xspace}
 % microtype handles punctuation at the right margin. We want it for
 % the final product, but it's okay if authors lack it.


### PR DESCRIPTION
It's easy enough to add the declaration directly to each document that needs it, but:
1. Maybe helpful to provide it universally
2. Harmless, as far as I can tell

Edit: The character in question is `‑`, not `-`.