### PR TITLE
Add [table] option to xcolor import

### DIFF
--- a/sp.cls
+++ b/sp.cls
@@ -154,7 +154,7 @@
   \newcommand{\printbibliography}{\bibliography{\@bibresources}}
 \fi
 
-\RequirePackage[usenames,dvipsnames]{xcolor}
+\RequirePackage[usenames,dvipsnames,table]{xcolor}
 \definecolor{splinkcolor}{rgb}{.0,.2,.4}
 \RequirePackage[colorlinks,breaklinks,
                 linkcolor=splinkcolor,


### PR DESCRIPTION
This causes the xcolor package to load and integrate with the [`colortbl` package](https://ctan.org/pkg/colortbl), for coloring rows / columns of tabular tables.

Otherwise, to get proper integration, the user has to call `\PassOptionsToPackage{table}{xcolor}` before `\documentclass{sp}`, which isn't terribly intuitive.

The `colortbl` package adds several commands that many users won't use, but they don't conflict with anything else, as far as I know, so no harm done.